### PR TITLE
oz 5 and remapping fixes

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,12 +19,16 @@ remappings = [
   "@chainlink/ccip-vendor/=lib/ccip/contracts/src/v0.8/vendor/",
   "forge-std/=lib/forge-std/src/",
   "@6551/=lib/reference/src/",
-  "@eigenlayer-contracts/=lib/eigenlayer-contracts/src/contracts/",
-  "@openzeppelin-v5/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/",
-  "@openzeppelin-v5/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/",
-  # Note: Eigenlayer uses OpenZeppelin v4
-  "@openzeppelin/contracts/=lib/eigenlayer-contracts/lib/openzeppelin-contracts/contracts/",
-  "@openzeppelin/contracts-upgradeable/=lib/eigenlayer-contracts/lib/openzeppelin-contracts-upgradeable/contracts/"
+  "@openzeppelin-v5-contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts",
+  "@openzeppelin-v5-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts",
+  "@eigenlayer-contracts=lib/eigenlayer-contracts/src/contracts",
+    # Note: We use OpenZeppelin v4.7 to deploy EigenLayer contracts (as EigenLayer does)
+  "@openzeppelin-v47-contracts/=lib/eigenlayer-contracts/lib/openzeppelin-contracts/contracts/",
+    # Context dependent remappings to avoid conflicts
+  "lib/openzeppelin-contracts-upgradeable:@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts",
+  "lib/openzeppelin-contracts-upgradeable:@openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts",
+  "lib/eigenlayer-contracts:@openzeppelin/contracts-upgradeable/=lib/eigenlayer-contracts/lib/openzeppelin-contracts-upgradeable",
+  "lib/eigenlayer-contracts:@openzeppelin/contracts/=lib/eigenlayer-contracts/lib/openzeppelin-contracts/contracts"
 ]
 
 [rpc_endpoints]

--- a/script/1_deployMockEigenlayerContracts.s.sol
+++ b/script/1_deployMockEigenlayerContracts.s.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.25;
 
 import {Script, stdJson} from "forge-std/Script.sol";
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
-import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-v47-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin-v47-contracts/proxy/transparent/ProxyAdmin.sol";
+import {IBeacon} from "@openzeppelin-v47-contracts/proxy/beacon/IBeacon.sol";
+import {UpgradeableBeacon} from "@openzeppelin-v47-contracts/proxy/beacon/UpgradeableBeacon.sol";
 
 import {IETHPOSDeposit} from "@eigenlayer-contracts/interfaces/IETHPOSDeposit.sol";
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";
@@ -28,7 +28,7 @@ import {StrategyFactory} from "@eigenlayer-contracts/strategies/StrategyFactory.
 import {StrategyBaseTVLLimits} from "@eigenlayer-contracts/strategies/StrategyBaseTVLLimits.sol";
 
 import {ERC20Minter} from "../test/mocks/ERC20Minter.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 import {IERC20_CCIPBnM} from "../src/interfaces/IERC20_CCIPBnM.sol";
 import {EthSepolia} from "./Addresses.sol";
 

--- a/script/2_deploySenderOnL2.s.sol
+++ b/script/2_deploySenderOnL2.s.sol
@@ -40,7 +40,7 @@ contract DeploySenderOnL2Script is Script, FileReader {
 
         vm.startBroadcast(deployerKey);
 
-        ProxyAdmin proxyAdmin = new ProxyAdmin();
+        ProxyAdmin proxyAdmin = new ProxyAdmin(deployer);
 
         // deploy sender utils proxy
         SenderHooks senderHooksProxy = SenderHooks(

--- a/script/2b_upgradeSenderOnL2.s.sol
+++ b/script/2b_upgradeSenderOnL2.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 import {Script} from "forge-std/Script.sol";
@@ -46,14 +46,16 @@ contract UpgradeSenderOnL2Script is Script, FileReader {
         /////////////////////////////
         vm.startBroadcast(deployerKey);
 
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(senderProxy))),
-            address(new SenderCCIP(BaseSepolia.Router))
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(payable(address(senderProxy))),
+            address(new SenderCCIP(BaseSepolia.Router)),
+            ""
         );
 
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(senderHooksProxy))),
-            address(new SenderHooks())
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(payable(address(senderHooksProxy))),
+            address(new SenderHooks()),
+            ""
         );
 
         /// whitelist destination chain

--- a/script/3_deployReceiverOnL1.s.sol
+++ b/script/3_deployReceiverOnL1.s.sol
@@ -95,7 +95,7 @@ contract DeployReceiverOnL1Script is Script, FileReader {
 
         vm.startBroadcast(deployerKey);
 
-        proxyAdmin = new ProxyAdmin();
+        proxyAdmin = new ProxyAdmin(address(this));
         // deploy 6551 Registry
         registry6551 = IERC6551Registry(address(new ERC6551Registry()));
         // deploy 6551 EigenAgentOwner NFT

--- a/script/3b_upgradeReceiverOnL1.s.sol
+++ b/script/3b_upgradeReceiverOnL1.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.25;
 
 import {Script} from "forge-std/Script.sol";
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
@@ -94,16 +94,18 @@ contract UpgradeReceiverOnL1Script is Script, FileReader {
 
 
         // upgrade 6551 EigenAgentOwner NFT
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(eigenAgentOwner721Proxy))),
-            address(new EigenAgentOwner721())
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(payable(address(eigenAgentOwner721Proxy))),
+            address(new EigenAgentOwner721()),
+            ""
         );
         eigenAgentOwner721Proxy.addToWhitelistedCallers(address(restakingConnectorProxy));
 
         // upgrade agentFactoryProxy
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(agentFactoryProxy))),
-            address(new AgentFactory())
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(payable(address(agentFactoryProxy))),
+            address(new AgentFactory()),
+            ""
         );
 
         //////////////////////////////////////////////////
@@ -111,17 +113,19 @@ contract UpgradeReceiverOnL1Script is Script, FileReader {
         //////////////////////////////////////////////////
 
         // Upgrade ReceiverCCIP proxy to new implementation
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(receiverProxy))),
-            address(new ReceiverCCIP(EthSepolia.Router))
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(payable(address(receiverProxy))),
+            address(new ReceiverCCIP(EthSepolia.Router)),
+            ""
         );
         vm.stopBroadcast();
 
         vm.startBroadcast(deployerKey);
         // Upgrade RestakingConnector proxy to new implementation
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(restakingConnectorProxy))),
-            address(new RestakingConnector())
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(payable(address(restakingConnectorProxy))),
+            address(new RestakingConnector()),
+            ""
         );
 
         receiverProxy.setRestakingConnector(restakingConnectorProxy);

--- a/script/6c_redeposit.s.sol
+++ b/script/6c_redeposit.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.25;
 
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 
 import {IEigenAgent6551} from "../src/6551/IEigenAgent6551.sol";
 import {EthSepolia} from "./Addresses.sol";

--- a/script/8_completeWithdrawal.s.sol
+++ b/script/8_completeWithdrawal.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.25;
 
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 
 import {IEigenAgent6551} from "../src/6551/IEigenAgent6551.sol";
 import {EthSepolia} from "./Addresses.sol";

--- a/script/BaseScript.sol
+++ b/script/BaseScript.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.25;
 import {Script} from "forge-std/Script.sol";
 // CCIP interfaces
 import {IRouterClient} from "@chainlink/ccip/interfaces/IRouterClient.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 import {IERC20_CCIPBnM} from "../src/interfaces/IERC20_CCIPBnM.sol";
 // Eigenlayer interfaecs
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";

--- a/script/ClientEncoders.sol
+++ b/script/ClientEncoders.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
 import {IRewardsCoordinator} from "@eigenlayer-contracts/interfaces/IRewardsCoordinator.sol";
 import {ISignatureUtils} from "@eigenlayer-contracts/interfaces/ISignatureUtils.sol";

--- a/script/ClientSigners.sol
+++ b/script/ClientSigners.sol
@@ -2,8 +2,7 @@
 pragma solidity 0.8.25;
 
 import {Script, console} from "forge-std/Script.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SignatureChecker} from "@openzeppelin-v5/contracts/utils/cryptography/SignatureChecker.sol";
+import {SignatureChecker} from "@openzeppelin-v5-contracts/utils/cryptography/SignatureChecker.sol";
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";
 
 
@@ -42,7 +41,7 @@ contract ClientSigners is Script {
 
     function createEigenlayerDepositDigest(
         IStrategy strategy,
-        IERC20 token,
+        address token,
         uint256 amount,
         address staker,
         uint256 nonce,

--- a/script/localhost/eigenlayerContracts.config.json
+++ b/script/localhost/eigenlayerContracts.config.json
@@ -1,15 +1,15 @@
 {
   "addresses": {
-    "DelegationManager": "0x5d53ec9Dd4cc2Ea816365c89877393f426d51D22",
-    "PauserRegistry": "0xfea3727CC88614F599A583Ea430A68411B06626a",
-    "ProxyAdmin": "0x81493F041Ba59192781e90f475b42A0b761671E5",
-    "RewardsCoordinator": "0xf3375b9c458B74a26454BC5AE62BC86aEAA60b47",
-    "StrategyBeacon": "0x5379b8575215D467f43Ba66d3b246E96723a20E4",
-    "StrategyFactory": "0xB2e861f772A89A1ED512FA0AFA3847d064210582",
-    "StrategyManager": "0x9f54627282f9004b3898cA6f646E14d910cEFA2c",
-    "TokenERC20": "0xb49907A0b1dc35a4c11Add4db78D6b90c5EF3e71",
+    "DelegationManager": "0x6d8D6bc33Aa4EA1F003aF3c3af4af70Ebe3E7701",
+    "PauserRegistry": "0xFC55e512C28f828C1A389Fc3D4BF8eED7c0d8775",
+    "ProxyAdmin": "0xAd38425194b504382a1e2eD77079b14ea85c4859",
+    "RewardsCoordinator": "0xDBECF7a4F0c44ddF311F0171D9D95900aDF271eC",
+    "StrategyBeacon": "0x0E8b5975045E608Bc170f30Ce5170d21531a5fBF",
+    "StrategyFactory": "0x7C358A920bD4a13Ec82508D757180ECE7D7a1535",
+    "StrategyManager": "0xE0a802447b20286eDd7CD4656b55C1FB94A99B40",
+    "TokenERC20": "0x9a95c4dAC924B10c1f29a4834D1132a7887b0228",
     "strategies": {
-      "CCIPStrategy": "0x5D92B5A52737E97D2B16cCf999A1552dff290Ba3"
+      "CCIPStrategy": "0xd7c9b72c5294C31c456663f2970737854EB3f9e9"
     }
   },
   "chainInfo": {
@@ -17,6 +17,6 @@
     "deploymentBlock": 1
   },
   "parameters": {
-    "deployer": "0x84cB641CF1f0cB67451cC2Eb7D2343Bc4ac18b9A"
+    "deployer": "0x892d81728eB3B33E463AEEdc2dC167130E74Be8c"
   }
 }

--- a/src/6551/AgentFactory.sol
+++ b/src/6551/AgentFactory.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {Initializable} from "@openzeppelin-v5-contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin-v5-contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {Clones} from "@openzeppelin-v5-contracts/proxy/Clones.sol";
 
 import {IERC6551Registry} from "@6551/interfaces/IERC6551Registry.sol";
 import {IEigenAgent6551} from "./IEigenAgent6551.sol";

--- a/src/6551/EigenAgent6551.sol
+++ b/src/6551/EigenAgent6551.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SignatureChecker} from "@openzeppelin-v5/contracts/utils/cryptography/SignatureChecker.sol";
+import {IERC1271} from "@openzeppelin-v5-contracts/interfaces/IERC1271.sol";
+import {IERC20} from "@openzeppelin-v5-contracts/token/ERC20/IERC20.sol";
+import {SignatureChecker} from "@openzeppelin-v5-contracts/utils/cryptography/SignatureChecker.sol";
 import {ERC6551Account as ERC6551} from "@6551/examples/simple/ERC6551Account.sol";
 
 import {IEigenAgentOwner721} from "./IEigenAgentOwner721.sol";

--- a/src/6551/EigenAgentOwner721.sol
+++ b/src/6551/EigenAgentOwner721.sol
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {ERC721URIStorageUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {ERC721URIStorageUpgradeable} from "@openzeppelin-v5-contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
+import {Initializable} from "@openzeppelin-v5-contracts-upgradeable/proxy/utils/Initializable.sol";
+import {Strings} from "@openzeppelin-v5-contracts/utils/Strings.sol";
 
 import {Adminable} from "../utils/Adminable.sol";
 import {IAgentFactory} from "./IAgentFactory.sol";
 
 
 contract EigenAgentOwner721 is Initializable, ERC721URIStorageUpgradeable, Adminable {
+    error AlreadyHasAgent(address owner);
 
     uint256 private _tokenIdCounter;
     IAgentFactory public agentFactory;
@@ -75,17 +76,16 @@ contract EigenAgentOwner721 is Initializable, ERC721URIStorageUpgradeable, Admin
         _setTokenURI(tokenId, string(abi.encodePacked("eigen-agent/", Strings.toString(tokenId), ".json")));
         return tokenId;
     }
-
+        
     /**
-     * @dev Hook to update EigenAgentOwner721 NFT owner whenever a NFT transfer occurs.
+     * @dev Update EigenAgentOwner721 NFT owner whenever a NFT transfer occurs.
      * This updates AgentFactory and keeps users matched with tokenIds (and associated ERC-6551 EigenAgents).
      */
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal override virtual {
+    function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
+        address from = super._update(to, tokenId, auth);
         require(balanceOf(to) <= 1, "Cannot own more than one EigenAgentOwner721 at a time.");
         agentFactory.updateEigenAgentOwnerTokenId(from, to, tokenId);
+        return from;
     }
+
 }

--- a/src/6551/IEigenAgentOwner721.sol
+++ b/src/6551/IEigenAgentOwner721.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721} from "@openzeppelin-v5-contracts/token/ERC721/IERC721.sol";
 import {IAdminable} from "../utils/Adminable.sol";
 import {IAgentFactory} from "../6551/IAgentFactory.sol";
 

--- a/src/BaseMessengerCCIP.sol
+++ b/src/BaseMessengerCCIP.sol
@@ -5,9 +5,9 @@ import {IRouterClient} from "@chainlink/ccip/interfaces/IRouterClient.sol";
 import {Client} from "@chainlink/ccip/libraries/Client.sol";
 import {CCIPReceiver} from "@chainlink/ccip/applications/CCIPReceiver.sol";
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {IERC20} from "@openzeppelin-v5-contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin-v5-contracts/token/ERC20/utils/SafeERC20.sol";
+import {OwnableUpgradeable} from "@openzeppelin-v5-contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 
 abstract contract BaseMessengerCCIP is CCIPReceiver, OwnableUpgradeable {
@@ -55,7 +55,7 @@ abstract contract BaseMessengerCCIP is CCIPReceiver, OwnableUpgradeable {
     constructor(address _router) CCIPReceiver(_router) { }
 
     function __BaseMessengerCCIP_init() internal {
-        OwnableUpgradeable.__Ownable_init();
+        OwnableUpgradeable.__Ownable_init(msg.sender);
     }
 
     /// @param _destinationChainSelector The selector of the destination chain.

--- a/src/ReceiverCCIP.sol
+++ b/src/ReceiverCCIP.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.25;
 
 import {Client} from "@chainlink/ccip/libraries/Client.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Initializable} from "@openzeppelin-v5-contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IERC20} from "@openzeppelin-v5-contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin-v5-contracts/token/ERC20/utils/SafeERC20.sol";
 import {IStrategyManager} from "@eigenlayer-contracts/interfaces/IStrategyManager.sol";
 
 import {FunctionSelectorDecoder} from "./utils/FunctionSelectorDecoder.sol";

--- a/src/RestakingConnector.sol
+++ b/src/RestakingConnector.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Initializable} from "@openzeppelin-v5-contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 import {Client} from "@chainlink/ccip/libraries/Client.sol";
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
 import {IStrategyManager} from "@eigenlayer-contracts/interfaces/IStrategyManager.sol";

--- a/src/SenderCCIP.sol
+++ b/src/SenderCCIP.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.25;
 
 import {Client} from "@chainlink/ccip/libraries/Client.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IERC20} from "@openzeppelin-v5-contracts/token/ERC20/IERC20.sol";
+import {Initializable} from "@openzeppelin-v5-contracts-upgradeable/proxy/utils/Initializable.sol";
 
 import {FunctionSelectorDecoder} from "./utils/FunctionSelectorDecoder.sol";
 import {BaseMessengerCCIP} from "./BaseMessengerCCIP.sol";

--- a/src/SenderHooks.sol
+++ b/src/SenderHooks.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Initializable} from "@openzeppelin-v5-contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
 import {IStrategyManager} from "@eigenlayer-contracts/interfaces/IStrategyManager.sol";
 import {IRewardsCoordinator} from "@eigenlayer-contracts/interfaces/IRewardsCoordinator.sol";

--- a/src/interfaces/IERC20_CCIPBnM.sol
+++ b/src/interfaces/IERC20_CCIPBnM.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v5-contracts/token/ERC20/IERC20.sol";
 
 interface IERC20_CCIPBnM is IERC20 {
 

--- a/src/utils/Adminable.sol
+++ b/src/utils/Adminable.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin-v5-contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 interface IAdminable {
     function addAdmin(address a) external;
@@ -14,7 +14,7 @@ contract Adminable is IAdminable, OwnableUpgradeable {
     mapping(address => bool) private admins;
 
     function __Adminable_init() internal initializer {
-        OwnableUpgradeable.__Ownable_init();
+        OwnableUpgradeable.__Ownable_init(msg.sender);
     }
 
     modifier onlyAdmin() {

--- a/src/utils/EigenlayerMsgDecoders.sol
+++ b/src/utils/EigenlayerMsgDecoders.sol
@@ -5,7 +5,7 @@ import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationMa
 import {IRewardsCoordinator} from "@eigenlayer-contracts/interfaces/IRewardsCoordinator.sol";
 import {ISignatureUtils} from "@eigenlayer-contracts/interfaces/ISignatureUtils.sol";
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 
 
 

--- a/src/utils/EigenlayerMsgEncoders.sol
+++ b/src/utils/EigenlayerMsgEncoders.sol
@@ -7,7 +7,7 @@ import {IStrategyManager} from "@eigenlayer-contracts/interfaces/IStrategyManage
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";
 import {IRewardsCoordinator} from "@eigenlayer-contracts/interfaces/IRewardsCoordinator.sol";
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 import {ISenderHooks} from "../interfaces/ISenderHooks.sol";
 import {IRestakingConnector} from "../interfaces/IRestakingConnector.sol";
 

--- a/test/BaseTestEnvironment.t.sol
+++ b/test/BaseTestEnvironment.t.sol
@@ -2,7 +2,8 @@
 pragma solidity 0.8.25;
 
 import {Test} from "forge-std/Test.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+// eigenlayer RewardsCoordinator is expecting v4.7 erc20
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 import {IERC20_CCIPBnM} from "../src/interfaces/IERC20_CCIPBnM.sol";
 
 import {IStrategyManager} from "@eigenlayer-contracts/interfaces/IStrategyManager.sol";

--- a/test/CCIP_ForkTest3_CompleteWithdrawal.t.sol
+++ b/test/CCIP_ForkTest3_CompleteWithdrawal.t.sol
@@ -5,9 +5,9 @@ import {console} from "forge-std/Test.sol";
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
 
 import {Client} from "@chainlink/ccip/libraries/Client.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
+import {ProxyAdmin} from "@openzeppelin-v5-contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-v5-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {DelegationManager} from "@eigenlayer-contracts/core/DelegationManager.sol";
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
@@ -459,7 +459,7 @@ contract CCIP_ForkTest_CompleteWithdrawal_Tests is BaseTestEnvironment, RouterFe
         IERC20 token3;
         IStrategy strategy3;
         {
-            ProxyAdmin proxyAdmin = new ProxyAdmin();
+            ProxyAdmin proxyAdmin = new ProxyAdmin(address(this));
 
             token3 = IERC20(address(
                 new TransparentUpgradeableProxy(

--- a/test/CCIP_ForkTest4_Delegation.t.sol
+++ b/test/CCIP_ForkTest4_Delegation.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.25;
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
 
 import {Client} from "@chainlink/ccip/libraries/Client.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
 import {ISignatureUtils} from "@eigenlayer-contracts/interfaces/ISignatureUtils.sol";

--- a/test/CCIP_ForkTest5_RewardsProcessClaim.t.sol
+++ b/test/CCIP_ForkTest5_RewardsProcessClaim.t.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.25;
 
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
 
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-v5-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin-v5-contracts/proxy/transparent/ProxyAdmin.sol";
 import {Client} from "@chainlink/ccip/libraries/Client.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 import {IERC20_CCIPBnM} from "../src/interfaces/IERC20_CCIPBnM.sol";
 import {ERC20Minter} from "./mocks/ERC20Minter.sol";
 
@@ -85,7 +85,7 @@ contract CCIP_ForkTest_RewardsProcessClaim_Tests is BaseTestEnvironment, RouterF
         // Create a second memecoin ERC20 token for multi-token rewards claims
         memecoin = IERC20(address(new TransparentUpgradeableProxy(
             address(new ERC20Minter()),
-            address(new ProxyAdmin()),
+            address(new ProxyAdmin(address(this))),
             abi.encodeWithSelector(
                 ERC20Minter.initialize.selector,
                 "token2",

--- a/test/ForkTests_BaseMessenger.t.sol
+++ b/test/ForkTests_BaseMessenger.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.25;
 
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
 
+import {OwnableUpgradeable} from "@openzeppelin-v5-contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {Client} from "@chainlink/ccip/libraries/Client.sol";
 import {IERC20_CCIPBnM} from "../src/interfaces/IERC20_CCIPBnM.sol";
 import {BaseSepolia, EthSepolia} from "../script/Addresses.sol";
@@ -55,7 +56,10 @@ contract ForkTests_BaseMessenger is BaseTestEnvironment, RouterFees {
         uint256 halfWithdraw = totalWithdraw / 2;
 
         vm.prank(bob);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            bob
+        ));
         receiverContract.withdrawToken(bob, address(tokenL1), totalWithdraw);
 
         // withdraw half, twice (all tokens)
@@ -84,7 +88,10 @@ contract ForkTests_BaseMessenger is BaseTestEnvironment, RouterFees {
         vm.deal(address(senderContract), 1.1 ether);
 
         vm.prank(bob);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            bob
+        ));
         senderContract.withdraw(bob, address(bob).balance);
 
         vm.prank(deployer);

--- a/test/ScriptsTests_ReadEigenlayerContracts.t.sol
+++ b/test/ScriptsTests_ReadEigenlayerContracts.t.sol
@@ -9,7 +9,7 @@ import {IRewardsCoordinator} from "@eigenlayer-contracts/interfaces/IRewardsCoor
 import {IPauserRegistry} from "@eigenlayer-contracts/interfaces/IPauserRegistry.sol";
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 
 import {DeployMockEigenlayerContractsScript} from "../script/1_deployMockEigenlayerContracts.s.sol";
 

--- a/test/TestERC20.sol
+++ b/test/TestERC20.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {ERC20} from "@openzeppelin-v5-contracts/token/ERC20/ERC20.sol";
+
+contract TestERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+}

--- a/test/UnitTests_AgentFactory.t.sol
+++ b/test/UnitTests_AgentFactory.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.25;
 
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
 
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-v5-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 import {EigenAgentOwner721} from "../src/6551/EigenAgentOwner721.sol";
@@ -69,7 +69,7 @@ contract UnitTests_AgentFactory is BaseTestEnvironment {
 
     function test_AgentFactory_Initialize() public {
 
-        ProxyAdmin pa = new ProxyAdmin();
+        ProxyAdmin pa = new ProxyAdmin(address(this));
         AgentFactory agentFactoryImpl = new AgentFactory();
         address mockBaseEigenAgent = vm.addr(4321);
         address mock6551Registry  = vm.addr(12341234);

--- a/test/UnitTests_ClientSignersEncoders.t.sol
+++ b/test/UnitTests_ClientSignersEncoders.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.25;
 
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
+import {IERC1271} from "@openzeppelin-v5-contracts/interfaces/IERC1271.sol";
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
 import {IRewardsCoordinator} from "@eigenlayer-contracts/interfaces/IRewardsCoordinator.sol";
@@ -94,7 +94,7 @@ contract UnitTests_ClientSignersEncoders is BaseTestEnvironment {
 
         bytes32 digest1 = clientSignersTest.createEigenlayerDepositDigest(
             strategy,
-            tokenL1,
+            address(tokenL1),
             amount,
             staker,
             execNonce,

--- a/test/UnitTests_Compare6551Costs.t.sol
+++ b/test/UnitTests_Compare6551Costs.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
-import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {ProxyAdmin} from "@openzeppelin-v5-contracts/proxy/transparent/ProxyAdmin.sol";
+import {Clones} from "@openzeppelin-v5-contracts/proxy/Clones.sol";
+import {IERC721} from "@openzeppelin-v5-contracts/token/ERC721/IERC721.sol";
 import {ERC6551Account} from "@6551/examples/simple/ERC6551Account.sol";
 
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
@@ -18,7 +18,7 @@ contract UnitTests_Compare6551Costs is BaseTestEnvironment {
     function setUp() public {
 
         setUpLocalEnvironment();
-        proxyAdmin = new ProxyAdmin();
+        proxyAdmin = new ProxyAdmin(address(this));
     }
 
     /*

--- a/test/UnitTests_EigenAgent.t.sol
+++ b/test/UnitTests_EigenAgent.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.25;
 
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC20} from "@openzeppelin-v5-contracts/token/ERC20/IERC20.sol";
+import {IERC1271} from "@openzeppelin-v5-contracts/interfaces/IERC1271.sol";
+import {IERC165} from "@openzeppelin-v5-contracts/utils/introspection/IERC165.sol";
 
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";

--- a/test/UnitTests_MsgEncodingDecoding.t.sol
+++ b/test/UnitTests_MsgEncodingDecoding.t.sol
@@ -7,7 +7,7 @@ import {ISignatureUtils} from "@eigenlayer-contracts/interfaces/ISignatureUtils.
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
 import {IRewardsCoordinator} from "@eigenlayer-contracts/interfaces/IRewardsCoordinator.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 
 import {
     AgentOwnerSignature,

--- a/test/UnitTests_ReceiverRestakingConnector.t.sol
+++ b/test/UnitTests_ReceiverRestakingConnector.t.sol
@@ -4,15 +4,15 @@ pragma solidity 0.8.25;
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
 
 import {Client} from "@chainlink/ccip/libraries/Client.sol";
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-
+import {OwnableUpgradeable} from "@openzeppelin-v5-contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-v5-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin-v5-contracts/proxy/transparent/ProxyAdmin.sol";
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
 import {IStrategyManager} from "@eigenlayer-contracts/interfaces/IStrategyManager.sol";
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";
 import {IRewardsCoordinator} from "@eigenlayer-contracts/interfaces/IRewardsCoordinator.sol";
 
+import {TestERC20} from "./TestERC20.sol";
 import {AgentFactory} from "../src/6551/AgentFactory.sol";
 import {ReceiverCCIP} from "../src/ReceiverCCIP.sol";
 import {RestakingConnector} from "../src/RestakingConnector.sol";
@@ -53,10 +53,16 @@ contract UnitTests_ReceiverRestakingConnector is BaseTestEnvironment {
 
         IRestakingConnector restakingImpl = IRestakingConnector(address(new RestakingConnector()));
 
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            address(this)
+        ));
         receiverContract.setRestakingConnector(IRestakingConnector(address(0)));
 
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            address(this)
+        ));
         receiverContract.setSenderContractL2(address(senderContract));
 
         vm.prank(deployer);
@@ -81,7 +87,7 @@ contract UnitTests_ReceiverRestakingConnector is BaseTestEnvironment {
      function test_Initialize_Receiver() public {
 
         ReceiverCCIP receiverImpl = new ReceiverCCIP(EthSepolia.Router);
-        ProxyAdmin pa = new ProxyAdmin();
+        ProxyAdmin pa = new ProxyAdmin(address(this));
 
         vm.expectRevert(
             abi.encodeWithSelector(AddressZero.selector, "RestakingConnector cannot be address(0)")
@@ -113,7 +119,7 @@ contract UnitTests_ReceiverRestakingConnector is BaseTestEnvironment {
      function test_Initialize_RestakingConnector() public {
 
         RestakingConnector restakingImpl = new RestakingConnector();
-        ProxyAdmin pa = new ProxyAdmin();
+        ProxyAdmin pa = new ProxyAdmin(address(this));
 
         vm.expectRevert(
             abi.encodeWithSelector(AddressZero.selector, "AgentFactory cannot be address(0)")
@@ -298,7 +304,7 @@ contract UnitTests_ReceiverRestakingConnector is BaseTestEnvironment {
             expiryShort
         );
 
-        ERC20 token2 = new ERC20("token2", "TKN2");
+        TestERC20 token2 = new TestERC20("token2", "TKN2");
 
         Client.EVMTokenAmount[] memory destTokenAmounts = new Client.EVMTokenAmount[](2);
         destTokenAmounts[0] = Client.EVMTokenAmount({
@@ -410,8 +416,10 @@ contract UnitTests_ReceiverRestakingConnector is BaseTestEnvironment {
 
 
     function test_RestakingConnector_SetAndGet_AgentFactory() public {
-
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            address(this)
+        ));
         restakingConnector.setAgentFactory(
             address(agentFactory)
         );
@@ -434,8 +442,10 @@ contract UnitTests_ReceiverRestakingConnector is BaseTestEnvironment {
     }
 
     function test_RestakingConnector_SetAndGet_EigenlayerContracts() public {
-
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            address(this)
+        ));
         restakingConnector.setEigenlayerContracts(
             delegationManager,
             strategyManager,
@@ -589,7 +599,10 @@ contract UnitTests_ReceiverRestakingConnector is BaseTestEnvironment {
         bytes32 messageId = bytes32(abi.encode(1,2,3));
 
         vm.prank(bob);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            bob
+        ));
         receiverContract.withdrawTokenForMessageId(messageId, bob, address(tokenL1), 1 ether);
 
         vm.expectRevert(abi.encodeWithSelector(WithdrawalExceedsBalance.selector, 2 ether, 1 ether));
@@ -632,7 +645,7 @@ contract UnitTests_ReceiverRestakingConnector is BaseTestEnvironment {
 
     function test_RestakingConnector_SetBridgeTokens() public {
 
-        ProxyAdmin proxyAdmin = new ProxyAdmin();
+        ProxyAdmin proxyAdmin = new ProxyAdmin(address(this));
 
         address _bridgeTokenL1 = vm.addr(1001);
         address _bridgeTokenL2 = vm.addr(2002);
@@ -679,7 +692,10 @@ contract UnitTests_ReceiverRestakingConnector is BaseTestEnvironment {
 
         vm.startBroadcast(bob);
         {
-            vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            bob
+        ));
             rc.setBridgeTokens(_bridgeTokenL1, _bridgeTokenL2);
         }
         vm.stopBroadcast();

--- a/test/UnitTests_SenderCCIP.t.sol
+++ b/test/UnitTests_SenderCCIP.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.25;
 
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
 
+import {OwnableUpgradeable} from "@openzeppelin-v5-contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {Client} from "@chainlink/ccip/libraries/Client.sol";
 import {SenderCCIP} from "../src/SenderCCIP.sol";
 import {SenderHooks} from "../src/SenderHooks.sol";
@@ -40,7 +41,10 @@ contract UnitTests_SenderCCIP is BaseTestEnvironment {
 
         vm.startBroadcast(bob);
         {
-            vm.expectRevert("Ownable: caller is not the owner");
+            vm.expectRevert(abi.encodeWithSelector(
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+                bob
+            ));
             senderContract.setSenderHooks(ISenderHooks(newSenderHooks));
         }
         vm.stopBroadcast();

--- a/test/UnitTests_SenderHooks.t.sol
+++ b/test/UnitTests_SenderHooks.t.sol
@@ -3,9 +3,11 @@ pragma solidity 0.8.25;
 
 import {BaseTestEnvironment} from "./BaseTestEnvironment.t.sol";
 
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Initializable} from "@openzeppelin-v5-contracts-upgradeable/proxy/utils/Initializable.sol";
+import {OwnableUpgradeable} from "@openzeppelin-v5-contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-v5-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin-v5-contracts/proxy/transparent/ProxyAdmin.sol";
+import {IERC20} from "@openzeppelin-v47-contracts/token/ERC20/IERC20.sol";
 import {IDelegationManager} from "@eigenlayer-contracts/interfaces/IDelegationManager.sol";
 import {IRewardsCoordinator} from "@eigenlayer-contracts/interfaces/IRewardsCoordinator.sol";
 import {IStrategy} from "@eigenlayer-contracts/interfaces/IStrategy.sol";
@@ -42,7 +44,10 @@ contract UnitTests_SenderHooks is BaseTestEnvironment {
 
     function test_SetAndGet_SenderCCIP() public {
 
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            address(this)
+        ));
         senderHooks.setSenderCCIP(address(senderContract));
 
         vm.expectRevert(abi.encodeWithSelector(AddressZero.selector, "SenderCCIP cannot be address(0)"));
@@ -57,7 +62,7 @@ contract UnitTests_SenderHooks is BaseTestEnvironment {
 
     function test_SenderHooks_SetBridgeTokens() public {
 
-        ProxyAdmin proxyAdmin = new ProxyAdmin();
+        ProxyAdmin proxyAdmin = new ProxyAdmin(address(this));
 
         address _bridgeTokenL1 = vm.addr(1001);
         address _bridgeTokenL2 = vm.addr(2002);
@@ -101,7 +106,10 @@ contract UnitTests_SenderHooks is BaseTestEnvironment {
 
         vm.startBroadcast(bob);
         {
-            vm.expectRevert("Ownable: caller is not the owner");
+            vm.expectRevert(abi.encodeWithSelector(
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+                bob
+            ));
             senderHooks.setBridgeTokens(_bridgeTokenL1, _bridgeTokenL2);
         }
         vm.stopBroadcast();
@@ -168,7 +176,7 @@ contract UnitTests_SenderHooks is BaseTestEnvironment {
     function test_DisableInitializers_SenderHooks() public {
         SenderHooks sHooks = new SenderHooks();
         // _disableInitializers on contract implementations
-        vm.expectRevert("Initializable: contract is already initialized");
+        vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
         sHooks.initialize(address(1), address(2));
     }
 

--- a/test/UnitTests_Utils.t.sol
+++ b/test/UnitTests_Utils.t.sol
@@ -4,8 +4,9 @@ pragma solidity 0.8.25;
 import {Test} from "forge-std/Test.sol";
 import {TestErrorHandlers} from "./TestErrorHandlers.sol";
 
-import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {OwnableUpgradeable} from "@openzeppelin-v5-contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-v5-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin-v5-contracts/proxy/transparent/ProxyAdmin.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 
@@ -37,7 +38,7 @@ contract UnitTests_Utils is Test, TestErrorHandlers {
             erc20Minter = ERC20Minter(address(
                 new TransparentUpgradeableProxy(
                     address(new ERC20Minter()),
-                    address(new ProxyAdmin()),
+                    address(new ProxyAdmin(deployer)),
                     abi.encodeWithSelector(ERC20Minter.initialize.selector, "test", "TST")
                 )
             ));
@@ -119,7 +120,10 @@ contract UnitTests_Utils is Test, TestErrorHandlers {
         vm.expectRevert("Not admin or owner");
         erc20Minter.mint(deployer, 1 ether);
 
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            address(this)
+        ));
         erc20Minter.burn(deployer, 1 ether);
 
         vm.prank(deployer);
@@ -145,7 +149,10 @@ contract UnitTests_Utils is Test, TestErrorHandlers {
         require(adminableMock.mockIsOwner() == false, "bob is not owner");
 
         vm.prank(bob);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            bob
+        ));
         adminableMock.addAdmin(bob);
 
         vm.prank(deployer);
@@ -157,7 +164,10 @@ contract UnitTests_Utils is Test, TestErrorHandlers {
         require(adminableMock.mockOnlyAdmin(), "should pass onlyAdmin modifier");
 
         vm.prank(bob);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(
+            OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+            bob
+        ));
         adminableMock.removeAdmin(bob);
 
         vm.prank(deployer);

--- a/test/mocks/ERC20Minter.sol
+++ b/test/mocks/ERC20Minter.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import {Initializable} from "@openzeppelin-v5-contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ERC20Upgradeable} from "@openzeppelin-v5-contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {Adminable} from "../../src/utils/Adminable.sol";
 
 

--- a/test/mocks/IERC20Minter.sol
+++ b/test/mocks/IERC20Minter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin-v5-contracts/token/ERC20/IERC20.sol";
 
 interface IERC20Minter is IERC20 {
 

--- a/test/mocks/MockMultisigSigner.sol
+++ b/test/mocks/MockMultisigSigner.sol
@@ -1,9 +1,9 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
-import {IERC721Receiver} from "@openzeppelin/contracts/interfaces/IERC721Receiver.sol";
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {IERC1271} from "@openzeppelin-v5-contracts/interfaces/IERC1271.sol";
+import {IERC721Receiver} from "@openzeppelin-v5-contracts/interfaces/IERC721Receiver.sol";
+import {ECDSA} from "@openzeppelin-v5-contracts/utils/cryptography/ECDSA.sol";
 import {Adminable} from "../../src/utils/Adminable.sol";
 
 


### PR DESCRIPTION
- use open zeppelin 5 where possible
- make oz versions more explicit in remappings
- use `context:` in remappings to fix openzeppelin / eigenlayer internal imports in the dependencies